### PR TITLE
fix(cypilot): harden pr.py status generation and diff fetching

### DIFF
--- a/skills/scripts/pr.py
+++ b/skills/scripts/pr.py
@@ -971,6 +971,7 @@ def main():
         if arg.upper() == "ALL":
             prs = _list_open_prs()
             excludes = _load_exclude_list()
+            failures = []
             for pr in prs:
                 num = str(pr["number"])
                 if num in excludes:
@@ -985,6 +986,9 @@ def main():
                         f"  Failed to generate status for PR #{num} (exit={e.code})",
                         file=sys.stderr,
                     )
+                    failures.append(num)
+            if failures:
+                sys.exit(1)
         else:
             status(arg)
 


### PR DESCRIPTION
- CONFIG_PATH now derived from PRS_DIR to honor dataDir config
- `status ALL` no longer skips PRs without pre-fetched meta.json
- `status ALL` catches per-PR failures so one error doesn't kill the batch
- `gh pr diff` HTTP 406 (diff too large) writes a placeholder instead of aborting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of large PR diffs—now saves placeholder content instead of failing
  * Enhanced bulk status operations to continue processing on individual PR errors rather than halting entirely
  * Added better error logging for oversized diff retrieval

<!-- end of auto-generated comment: release notes by coderabbit.ai -->