### PR TITLE
docs(readme): Fix CDSL (Cypilot Domain-Specific Language).

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ _Read `ADAPTER.md`_
 
   `ADAPTER → PRD → OVERALL DESIGN → FEATURE → CODE`
 
-- [No coding in DESIGN.md]: Actor flows / algorithms should be in Cypilot DSL (CDSL) where required, not embedded code.
+- [No coding in DESIGN.md]: Actor flows / algorithms should be in Cypilot Domain-Specific Language (CDSL) where required, not embedded code.
 - [Validation-first mindset]: We'll aim for the required scores (Overall ≥90/100, Feature 100/100) before "locking in" implementation direction.
 
 #### How to ask (examples you can copy/paste)

--- a/architecture/DECOMPOSITION.md
+++ b/architecture/DECOMPOSITION.md
@@ -14,13 +14,13 @@ Cypilot features are organized around **architectural components** with explicit
 
 - [x] `p1` - **ID**: `cpt-cypilot-feature-methodology-core`
 
-- **Purpose**: Provide universal Cypilot specifications including requirements, CDSL language, and base template syntax that all projects share.
+- **Purpose**: Provide universal Cypilot specifications including requirements, Cypilot Domain-Specific Language (CDSL), and base template syntax that all projects share.
 
 - **Depends On**: None
 
 - **Scope**:
   - Requirements specifications (`requirements/*.md`)
-  - CDSL (Cypilot Description Language) specification
+  - CDSL (Cypilot Domain-Specific Language) specification
   - ID formats and naming specification
   - Execution protocol definition
 


### PR DESCRIPTION
- Correct CDSL (Cypilot Description Language) to CDSL (Cypilot Domain-Specific Language)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated terminology references across documentation to standardize the acronym as "Cypilot Domain-Specific Language (CDSL)" for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->