### PR TITLE
fix(cypilot): parse ID kinds correctly for hyphenated system slugs

### DIFF
--- a/skills/cypilot/scripts/cypilot/utils/constraints.py
+++ b/skills/cypilot/scripts/cypilot/utils/constraints.py
@@ -564,6 +564,28 @@ def validate_artifact_file(
                 pp = p.strip().lower()
                 if pp in nested_kinds and pp != base:
                     return pp
+
+        # Standard IDs are cpt-{system}-{kind}-{slug}. In practice, when a
+        # registered root system is used (e.g. "cf"), authors may include a
+        # hyphenated subsystem segment before kind (e.g. "cf-errors").
+        # In that case, the first token in remainder is not the kind.
+        # Prefer explicit kind-token markers in remainder.
+        kind_tokens = {str(k).strip().lower() for k in _all_kind_tokens if str(k).strip()}
+        if base in kind_tokens:
+            return base
+
+        rem_l = remainder.lower()
+        best_pos: Optional[int] = None
+        best_kind: Optional[str] = None
+        for kt in kind_tokens:
+            marker = f"-{kt}-"
+            idx = rem_l.find(marker)
+            if idx > 0 and (best_pos is None or idx < best_pos):
+                best_pos = idx
+                best_kind = kt
+
+        if best_kind is not None:
+            return best_kind
         return base
 
     defs_by_kind: Dict[str, List[Dict[str, object]]] = {}
@@ -863,6 +885,25 @@ def cross_validate_artifacts(
                 pp = p.strip().lower()
                 if pp in nested_kinds and pp != base:
                     return pp
+
+        # Handle IDs like cpt-cf-errors-actor-ci-pipeline where "cf" is the
+        # registered system and "errors" is a subsystem segment.
+        kind_tokens = {str(k).strip().lower() for k in _cross_all_kind_tokens if str(k).strip()}
+        if base in kind_tokens:
+            return base
+
+        rem_l = remainder.lower()
+        best_pos: Optional[int] = None
+        best_kind: Optional[str] = None
+        for kt in kind_tokens:
+            marker = f"-{kt}-"
+            idx = rem_l.find(marker)
+            if idx > 0 and (best_pos is None or idx < best_pos):
+                best_pos = idx
+                best_kind = kt
+
+        if best_kind is not None:
+            return best_kind
         return base
 
     def is_external_system_ref(cpt: str) -> bool:

--- a/tests/test_constraints_utils.py
+++ b/tests/test_constraints_utils.py
@@ -601,6 +601,34 @@ def test_validate_artifact_file_id_system_unrecognized(tmp_path: Path):
     assert EC.ID_SYSTEM_UNRECOGNIZED in codes
 
 
+def test_validate_artifact_file_registered_system_with_hyphenated_subsystem_kind_parse(tmp_path: Path):
+    """When registered root system is used, hyphenated subsystem must not become id kind."""
+    kc, errs = parse_kit_constraints({
+        "PRD": {
+            "identifiers": {
+                "actor": {"required": False},
+                "fr": {"required": False},
+            }
+        }
+    })
+    assert errs == []
+
+    p = tmp_path / "PRD.md"
+    p.write_text(
+        "**ID**: `cpt-cf-errors-actor-ci-pipeline`\n",
+        encoding="utf-8",
+    )
+
+    rep = validate_artifact_file(
+        artifact_path=p,
+        artifact_kind="PRD",
+        constraints=kc.by_kind["PRD"],
+        registered_systems={"cf"},
+    )
+    kind_errors = [e for e in (rep.get("errors") or []) if e.get("code") == EC.ID_KIND_NOT_ALLOWED]
+    assert kind_errors == [], f"Unexpected kind parsing errors: {kind_errors}"
+
+
 def test_cross_validate_no_registered_systems_compound_system(tmp_path: Path):
     """cross_validate with registered_systems=None handles compound system names."""
     kc, errs = parse_kit_constraints({
@@ -628,6 +656,23 @@ def test_cross_validate_no_registered_systems_compound_system(tmp_path: Path):
     # Should NOT have ref-no-definition (system must be "my-design", not "my")
     ref_no_def = [e for e in errs if e.get("code") == EC.REF_NO_DEFINITION]
     assert ref_no_def == [], f"Unexpected ref-no-definition: {ref_no_def}"
+
+
+def test_cross_validate_registered_system_with_hyphenated_subsystem_kind_parse(tmp_path: Path):
+    kc, errs = parse_kit_constraints({
+        "PRD": {"identifiers": {"actor": {"required": False}}},
+    })
+    assert errs == []
+
+    prd = tmp_path / "PRD.md"
+    prd.write_text("**ID**: `cpt-cf-errors-actor-ci-pipeline`\n", encoding="utf-8")
+
+    arts = [
+        ArtifactRecord(path=prd, artifact_kind="PRD", constraints=kc.by_kind["PRD"]),
+    ]
+    rep = cross_validate_artifacts(arts, registered_systems={"cf"}, known_kinds={"actor"})
+    kind_errors = [e for e in (rep.get("errors") or []) if e.get("code") == EC.ID_KIND_NOT_ALLOWED]
+    assert kind_errors == [], f"Unexpected cross-validate kind errors: {kind_errors}"
 
 
 def test_cross_validate_reference_done_but_definition_not_done(tmp_path: Path):


### PR DESCRIPTION
- fix CDSL ID kind extraction for IDs like `cpt-cf-errors-actor-ci-pipeline`
- stop misclassifying `errors` as kind when it is part of system slug
- update kind extraction logic in both artifact and cross-artifact validators
- add regression tests for registered-system + hyphenated-subsystem scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of composite ID parsing when hyphenated subsystems are present, ensuring complex IDs are correctly interpreted without misidentifying subsystem tokens as kinds.

* **Tests**
  * Added test cases to validate correct parsing of IDs with hyphenated subsystem prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->