### PR TITLE
feat: Add Python <3.11 compatibility for tomllib imports

### DIFF
--- a/.bootstrap/.core/skills/cypilot/scripts/cypilot/commands/_core_config.py
+++ b/.bootstrap/.core/skills/cypilot/scripts/cypilot/commands/_core_config.py
@@ -6,8 +6,9 @@
 from __future__ import annotations
 
 import logging
-import tomllib
 from pathlib import Path
+
+from ..utils._tomllib_compat import tomllib
 
 logger = logging.getLogger(__name__)
 

--- a/.bootstrap/.core/skills/cypilot/scripts/cypilot/commands/adapter_info.py
+++ b/.bootstrap/.core/skills/cypilot/scripts/cypilot/commands/adapter_info.py
@@ -12,6 +12,7 @@ import json
 from pathlib import Path
 from typing import Optional
 
+from ..utils._tomllib_compat import tomllib
 from ..utils.files import (
     find_cypilot_directory,
     find_project_root,
@@ -33,7 +34,7 @@ def _load_json_file(path: Path) -> Optional[dict]:
 def _read_kit_conf(conf_path: Path) -> dict:
     """Read kit conf.toml and return key fields."""
     try:
-        import tomllib
+
         with open(conf_path, "rb") as f:
             data = tomllib.load(f)
         out: dict = {}
@@ -107,7 +108,7 @@ def cmd_adapter_info(argv: list[str]) -> int:
     registry = _load_json_file(registry_path) if registry_path.suffix == ".json" else None
     if registry is None and registry_path.suffix == ".toml" and registry_path.is_file():
         try:
-            import tomllib
+
             with open(registry_path, "rb") as f:
                 registry = tomllib.load(f)
         except (OSError, ValueError):
@@ -118,10 +119,9 @@ def cmd_adapter_info(argv: list[str]) -> int:
     for cp in [(adapter_dir / "config" / "core.toml"), (adapter_dir / "core.toml")]:
         if cp.is_file():
             try:
-                import tomllib as _tl
                 with open(cp, "rb") as f:
-                    core_data = _tl.load(f)
-            except (_tl.TOMLDecodeError, OSError) as exc:
+                    core_data = tomllib.load(f)
+            except (tomllib.TOMLDecodeError, OSError) as exc:
                 core_load_error = f"{type(exc).__name__}: {exc}"
             break
 

--- a/.bootstrap/.core/skills/cypilot/scripts/cypilot/commands/agents.py
+++ b/.bootstrap/.core/skills/cypilot/scripts/cypilot/commands/agents.py
@@ -30,9 +30,10 @@ import json
 import re
 import shutil
 import sys
-import tomllib
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
+
+from ..utils._tomllib_compat import tomllib
 
 # Regex for valid TOML bare key / agent name: ASCII letters, digits, hyphen, underscore.
 _VALID_AGENT_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")

--- a/.bootstrap/.core/skills/cypilot/scripts/cypilot/commands/init.py
+++ b/.bootstrap/.core/skills/cypilot/scripts/cypilot/commands/init.py
@@ -7,6 +7,7 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from ..utils._tomllib_compat import tomllib
 from ..utils.artifacts_meta import create_backup, generate_default_registry, generate_slug
 from ..utils import toml_utils
 from ..utils.ui import ui
@@ -257,7 +258,6 @@ def _read_existing_install(project_root: Path) -> Optional[str]:
 
     Returns install dir relative path if found, None otherwise.
     """
-    import tomllib
     agents_file = project_root / _AGENTS_FILENAME
     if not agents_file.is_file():
         return None

--- a/.bootstrap/.core/skills/cypilot/scripts/cypilot/commands/kit.py
+++ b/.bootstrap/.core/skills/cypilot/scripts/cypilot/commands/kit.py
@@ -19,6 +19,7 @@ import urllib.request
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any, Dict, List, Optional, Tuple
 
+from ..utils._tomllib_compat import tomllib
 from ..utils.ui import ui
 from ..utils.whatsnew import show_kit_whatsnew
 # @cpt-end:cpt-cypilot-algo-kit-github-helpers:p1:inst-kit-imports
@@ -638,7 +639,7 @@ def _read_project_name_from_registry(config_dir: Path) -> Optional[str]:
     if not artifacts_toml.is_file():
         return None
     try:
-        import tomllib
+
         with open(artifacts_toml, "rb") as f:
             data = tomllib.load(f)
         systems = data.get("systems", [])
@@ -1707,7 +1708,7 @@ def _read_conf_version(conf_path: Path) -> int:
     if not conf_path.is_file():
         return 0
     try:
-        import tomllib
+
         with open(conf_path, "rb") as f:
             data = tomllib.load(f)
         ver = data.get("version")
@@ -1838,7 +1839,7 @@ def _update_core_toml_kit_paths(config_dir: Path) -> None:
     core_toml = config_dir / _KIT_CORE_TOML
     if not core_toml.is_file():
         return
-    import tomllib
+
     with open(core_toml, "rb") as f:
         data = tomllib.load(f)
     kits_conf = data.get("kits", {})
@@ -2363,7 +2364,7 @@ def _read_kits_from_core_toml(config_dir: Path) -> Dict[str, Dict[str, Any]]:
     if not core_toml.is_file():
         return {}
     try:
-        import tomllib
+
         with open(core_toml, "rb") as f:
             data = tomllib.load(f)
     except (OSError, ValueError):
@@ -2384,7 +2385,7 @@ def _read_kit_slug(kit_source: Path) -> str:
     if not conf_toml.is_file():
         return ""
     try:
-        import tomllib
+
         with open(conf_toml, "rb") as f:
             data = tomllib.load(f)
         slug = data.get("slug")
@@ -2404,7 +2405,7 @@ def _read_kit_version_from_core(config_dir: Path, kit_slug: str) -> str:
     if not core_toml.is_file():
         return ""
     try:
-        import tomllib
+
         with open(core_toml, "rb") as f:
             data = tomllib.load(f)
         kit_entry = data.get("kits", {}).get(kit_slug, {})
@@ -2422,7 +2423,7 @@ def _read_kit_version(conf_path: Path) -> str:
     """Read kit version from conf.toml."""
     # @cpt-begin:cpt-cypilot-algo-kit-config-helpers:p1:inst-read-kit-version
     try:
-        import tomllib
+
         with open(conf_path, "rb") as f:
             data = tomllib.load(f)
         ver = data.get("version")
@@ -2451,7 +2452,7 @@ def _register_kit_in_core_toml(
         return
 
     try:
-        import tomllib
+
         with open(core_toml, "rb") as f:
             data = tomllib.load(f)
     except (OSError, ValueError):

--- a/.bootstrap/.core/skills/cypilot/scripts/cypilot/commands/resolve_vars.py
+++ b/.bootstrap/.core/skills/cypilot/scripts/cypilot/commands/resolve_vars.py
@@ -17,6 +17,7 @@ import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+from ..utils._tomllib_compat import tomllib
 from ..utils.files import (
     find_cypilot_directory,
     find_project_root,
@@ -333,7 +334,7 @@ def cmd_resolve_vars(argv: list[str]) -> int:
     ]:
         if cp.is_file():
             try:
-                import tomllib
+
                 with open(cp, "rb") as f:
                     core_data = tomllib.load(f)
             except (tomllib.TOMLDecodeError, OSError) as exc:

--- a/.bootstrap/.core/skills/cypilot/scripts/cypilot/commands/update.py
+++ b/.bootstrap/.core/skills/cypilot/scripts/cypilot/commands/update.py
@@ -30,6 +30,7 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from ..utils._tomllib_compat import tomllib
 from .init import (
     CACHE_DIR,
     COPY_ARCHITECTURE_ITEMS,
@@ -639,7 +640,7 @@ def _remove_system_from_core_toml(config_dir: Path) -> bool:
         return False
 
     try:
-        import tomllib
+
         with open(core_toml, "rb") as f:
             data = tomllib.load(f)
     except (OSError, ValueError) as exc:
@@ -686,7 +687,7 @@ def _deduplicate_legacy_kits(config_dir: Path) -> Dict[str, str]:
         return {}
 
     try:
-        import tomllib
+
         with open(core_toml, "rb") as f:
             data = tomllib.load(f)
     except (OSError, ValueError):
@@ -730,9 +731,8 @@ def _deduplicate_legacy_kits(config_dir: Path) -> Dict[str, str]:
     artifacts_toml = config_dir / "artifacts.toml"
     if artifacts_toml.is_file():
         try:
-            import tomllib as _tomllib
             with open(artifacts_toml, "rb") as f:
-                reg = _tomllib.load(f)
+                reg = tomllib.load(f)
 
             changed = False
             for sys_entry in reg.get("systems", []):
@@ -773,7 +773,7 @@ def _migrate_kit_sources(config_dir: Path) -> Dict[str, str]:
         return {}
 
     try:
-        import tomllib
+
         with open(core_toml, "rb") as f:
             data = tomllib.load(f)
     except (OSError, ValueError):

--- a/.bootstrap/.core/skills/cypilot/scripts/cypilot/ralphex_export.py
+++ b/.bootstrap/.core/skills/cypilot/scripts/cypilot/ralphex_export.py
@@ -18,10 +18,10 @@ import os
 import re
 import subprocess
 import sys
-import tomllib
 from pathlib import Path
 from typing import Optional
 
+from .utils._tomllib_compat import tomllib
 from .utils.files import _read_cypilot_var, core_subpath
 
 logger = logging.getLogger(__name__)

--- a/.bootstrap/.core/skills/cypilot/scripts/cypilot/utils/_tomllib_compat.py
+++ b/.bootstrap/.core/skills/cypilot/scripts/cypilot/utils/_tomllib_compat.py
@@ -1,0 +1,29 @@
+"""
+Compatibility shim for tomllib (Python 3.11+) / tomli (Python < 3.11).
+
+Import this module instead of importing tomllib directly:
+
+    from cypilot.utils._tomllib_compat import tomllib
+
+@cpt-algo:cpt-cypilot-algo-core-infra-config-management:p1
+"""
+
+import sys
+
+# Python 3.11+ has tomllib in stdlib, earlier versions need tomli
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    try:
+        import tomli as tomllib
+    except ImportError:
+        print(
+            "ERROR: tomllib/tomli not available.\n"
+            "Please either:\n"
+            "  1. Use Python 3.11+ (tomllib is included in stdlib), or\n"
+            "  2. Install tomli: pip install tomli\n",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+__all__ = ["tomllib"]

--- a/.bootstrap/.core/skills/cypilot/scripts/cypilot/utils/artifacts_meta.py
+++ b/.bootstrap/.core/skills/cypilot/scripts/cypilot/utils/artifacts_meta.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, Dict, Iterator, List, Optional, Set, Tuple
 
+from ._tomllib_compat import tomllib
 from ..constants import ARTIFACTS_REGISTRY_FILENAME
 
 # @cpt-begin:cpt-cypilot-algo-core-infra-registry-parsing:p1:inst-reg-dataclasses
@@ -1053,7 +1054,6 @@ def load_artifacts_meta(adapter_dir: Path) -> Tuple[Optional[ArtifactsMeta], Opt
     # @cpt-begin:cpt-cypilot-algo-core-infra-registry-parsing:p1:inst-reg-parse-merge
     try:
         if path.suffix == ".toml":
-            import tomllib
             with open(path, "rb") as f:
                 data = tomllib.load(f)
         else:
@@ -1067,9 +1067,8 @@ def load_artifacts_meta(adapter_dir: Path) -> Tuple[Optional[ArtifactsMeta], Opt
         if not core_path.is_file():
             core_path = adapter_dir / "core.toml"
         if core_path.is_file():
-            import tomllib as _tl
             with open(core_path, "rb") as f:
-                core = _tl.load(f)
+                core = tomllib.load(f)
             # version and project_root: core.toml is authoritative, artifacts.toml is fallback
             if isinstance(core.get("version"), str) and "version" not in data:
                 data["version"] = core["version"]

--- a/.bootstrap/.core/skills/cypilot/scripts/cypilot/utils/layer_discovery.py
+++ b/.bootstrap/.core/skills/cypilot/scripts/cypilot/utils/layer_discovery.py
@@ -12,10 +12,10 @@ by walking up the filesystem from the repo root.
 from __future__ import annotations
 
 import logging
-import tomllib
 from pathlib import Path
 from typing import List, Optional
 
+from ._tomllib_compat import tomllib
 from .manifest import ManifestLayer, ManifestLayerState, parse_manifest_v2, _rewrite_component_paths
 # @cpt-end:cpt-cypilot-algo-project-extensibility-walk-up-discovery:p1:inst-imports
 

--- a/.bootstrap/.core/skills/cypilot/scripts/cypilot/utils/manifest.py
+++ b/.bootstrap/.core/skills/cypilot/scripts/cypilot/utils/manifest.py
@@ -17,11 +17,12 @@ from __future__ import annotations
 
 import re
 import string
-import tomllib
 from dataclasses import dataclass, field, replace
 from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
+
+from ._tomllib_compat import tomllib
 
 
 # ---------------------------------------------------------------------------

--- a/.bootstrap/.core/skills/cypilot/scripts/cypilot/utils/toml_utils.py
+++ b/.bootstrap/.core/skills/cypilot/scripts/cypilot/utils/toml_utils.py
@@ -10,9 +10,10 @@ TOML utilities for Cypilot config files.
 
 # @cpt-begin:cpt-cypilot-algo-core-infra-toml-utils:p1:inst-toml-datamodel
 import re
-import tomllib
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+from ._tomllib_compat import tomllib
 
 TomlData = Dict[str, Any]
 

--- a/.bootstrap/.core/skills/cypilot/scripts/cypilot/utils/whatsnew.py
+++ b/.bootstrap/.core/skills/cypilot/scripts/cypilot/utils/whatsnew.py
@@ -11,6 +11,8 @@ import sys
 from pathlib import Path
 from typing import Dict, Tuple
 
+from ._tomllib_compat import tomllib
+
 logger = logging.getLogger(__name__)
 
 # @cpt-begin:cpt-cypilot-algo-kit-whatsnew-display:p1:inst-whatsnew-format
@@ -128,11 +130,6 @@ def read_whatsnew(path: Path) -> Dict[str, Dict[str, str]]:
     Keys may be in format "whatsnew.X.Y.Z" (from TOML section) or just "X.Y.Z".
     """
     if not path.is_file():
-        return {}
-    try:
-        import tomllib
-    except ModuleNotFoundError as e:
-        logger.debug("Failed to parse %s: %s", path, e)
         return {}
     try:
         with open(path, "rb") as f:

--- a/skills/cypilot/scripts/cypilot/commands/_core_config.py
+++ b/skills/cypilot/scripts/cypilot/commands/_core_config.py
@@ -6,8 +6,9 @@
 from __future__ import annotations
 
 import logging
-import tomllib
 from pathlib import Path
+
+from ..utils._tomllib_compat import tomllib
 
 logger = logging.getLogger(__name__)
 

--- a/skills/cypilot/scripts/cypilot/commands/adapter_info.py
+++ b/skills/cypilot/scripts/cypilot/commands/adapter_info.py
@@ -12,6 +12,7 @@ import json
 from pathlib import Path
 from typing import Optional
 
+from ..utils._tomllib_compat import tomllib
 from ..utils.files import (
     find_cypilot_directory,
     find_project_root,
@@ -33,7 +34,6 @@ def _load_json_file(path: Path) -> Optional[dict]:
 def _read_kit_conf(conf_path: Path) -> dict:
     """Read kit conf.toml and return key fields."""
     try:
-        import tomllib
         with open(conf_path, "rb") as f:
             data = tomllib.load(f)
         out: dict = {}
@@ -107,7 +107,6 @@ def cmd_adapter_info(argv: list[str]) -> int:
     registry = _load_json_file(registry_path) if registry_path.suffix == ".json" else None
     if registry is None and registry_path.suffix == ".toml" and registry_path.is_file():
         try:
-            import tomllib
             with open(registry_path, "rb") as f:
                 registry = tomllib.load(f)
         except (OSError, ValueError):
@@ -118,10 +117,9 @@ def cmd_adapter_info(argv: list[str]) -> int:
     for cp in [(adapter_dir / "config" / "core.toml"), (adapter_dir / "core.toml")]:
         if cp.is_file():
             try:
-                import tomllib as _tl
                 with open(cp, "rb") as f:
-                    core_data = _tl.load(f)
-            except (_tl.TOMLDecodeError, OSError) as exc:
+                    core_data = tomllib.load(f)
+            except (tomllib.TOMLDecodeError, OSError) as exc:
                 core_load_error = f"{type(exc).__name__}: {exc}"
             break
 

--- a/skills/cypilot/scripts/cypilot/commands/agents.py
+++ b/skills/cypilot/scripts/cypilot/commands/agents.py
@@ -30,9 +30,10 @@ import json
 import re
 import shutil
 import sys
-import tomllib
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
+
+from ..utils._tomllib_compat import tomllib
 
 # Regex for valid TOML bare key / agent name: ASCII letters, digits, hyphen, underscore.
 _VALID_AGENT_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")

--- a/skills/cypilot/scripts/cypilot/commands/init.py
+++ b/skills/cypilot/scripts/cypilot/commands/init.py
@@ -7,6 +7,7 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from ..utils._tomllib_compat import tomllib
 from ..utils.artifacts_meta import create_backup, generate_default_registry, generate_slug
 from ..utils import toml_utils
 from ..utils.ui import ui
@@ -257,7 +258,6 @@ def _read_existing_install(project_root: Path) -> Optional[str]:
 
     Returns install dir relative path if found, None otherwise.
     """
-    import tomllib
     agents_file = project_root / _AGENTS_FILENAME
     if not agents_file.is_file():
         return None

--- a/skills/cypilot/scripts/cypilot/commands/kit.py
+++ b/skills/cypilot/scripts/cypilot/commands/kit.py
@@ -19,6 +19,7 @@ import urllib.request
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any, Dict, List, Optional, Tuple
 
+from ..utils._tomllib_compat import tomllib
 from ..utils.ui import ui
 from ..utils.whatsnew import show_kit_whatsnew
 # @cpt-end:cpt-cypilot-algo-kit-github-helpers:p1:inst-kit-imports
@@ -638,7 +639,6 @@ def _read_project_name_from_registry(config_dir: Path) -> Optional[str]:
     if not artifacts_toml.is_file():
         return None
     try:
-        import tomllib
         with open(artifacts_toml, "rb") as f:
             data = tomllib.load(f)
         systems = data.get("systems", [])
@@ -1707,7 +1707,6 @@ def _read_conf_version(conf_path: Path) -> int:
     if not conf_path.is_file():
         return 0
     try:
-        import tomllib
         with open(conf_path, "rb") as f:
             data = tomllib.load(f)
         ver = data.get("version")
@@ -1838,7 +1837,6 @@ def _update_core_toml_kit_paths(config_dir: Path) -> None:
     core_toml = config_dir / _KIT_CORE_TOML
     if not core_toml.is_file():
         return
-    import tomllib
     with open(core_toml, "rb") as f:
         data = tomllib.load(f)
     kits_conf = data.get("kits", {})
@@ -2363,7 +2361,6 @@ def _read_kits_from_core_toml(config_dir: Path) -> Dict[str, Dict[str, Any]]:
     if not core_toml.is_file():
         return {}
     try:
-        import tomllib
         with open(core_toml, "rb") as f:
             data = tomllib.load(f)
     except (OSError, ValueError):
@@ -2384,7 +2381,6 @@ def _read_kit_slug(kit_source: Path) -> str:
     if not conf_toml.is_file():
         return ""
     try:
-        import tomllib
         with open(conf_toml, "rb") as f:
             data = tomllib.load(f)
         slug = data.get("slug")
@@ -2404,7 +2400,6 @@ def _read_kit_version_from_core(config_dir: Path, kit_slug: str) -> str:
     if not core_toml.is_file():
         return ""
     try:
-        import tomllib
         with open(core_toml, "rb") as f:
             data = tomllib.load(f)
         kit_entry = data.get("kits", {}).get(kit_slug, {})
@@ -2422,7 +2417,6 @@ def _read_kit_version(conf_path: Path) -> str:
     """Read kit version from conf.toml."""
     # @cpt-begin:cpt-cypilot-algo-kit-config-helpers:p1:inst-read-kit-version
     try:
-        import tomllib
         with open(conf_path, "rb") as f:
             data = tomllib.load(f)
         ver = data.get("version")
@@ -2451,7 +2445,6 @@ def _register_kit_in_core_toml(
         return
 
     try:
-        import tomllib
         with open(core_toml, "rb") as f:
             data = tomllib.load(f)
     except (OSError, ValueError):

--- a/skills/cypilot/scripts/cypilot/commands/resolve_vars.py
+++ b/skills/cypilot/scripts/cypilot/commands/resolve_vars.py
@@ -17,6 +17,7 @@ import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+from ..utils._tomllib_compat import tomllib
 from ..utils.files import (
     find_cypilot_directory,
     find_project_root,
@@ -333,7 +334,6 @@ def cmd_resolve_vars(argv: list[str]) -> int:
     ]:
         if cp.is_file():
             try:
-                import tomllib
                 with open(cp, "rb") as f:
                     core_data = tomllib.load(f)
             except (tomllib.TOMLDecodeError, OSError) as exc:

--- a/skills/cypilot/scripts/cypilot/commands/update.py
+++ b/skills/cypilot/scripts/cypilot/commands/update.py
@@ -30,6 +30,7 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from ..utils._tomllib_compat import tomllib
 from .init import (
     CACHE_DIR,
     COPY_ARCHITECTURE_ITEMS,
@@ -639,7 +640,6 @@ def _remove_system_from_core_toml(config_dir: Path) -> bool:
         return False
 
     try:
-        import tomllib
         with open(core_toml, "rb") as f:
             data = tomllib.load(f)
     except (OSError, ValueError) as exc:
@@ -686,7 +686,6 @@ def _deduplicate_legacy_kits(config_dir: Path) -> Dict[str, str]:
         return {}
 
     try:
-        import tomllib
         with open(core_toml, "rb") as f:
             data = tomllib.load(f)
     except (OSError, ValueError):
@@ -730,9 +729,8 @@ def _deduplicate_legacy_kits(config_dir: Path) -> Dict[str, str]:
     artifacts_toml = config_dir / "artifacts.toml"
     if artifacts_toml.is_file():
         try:
-            import tomllib as _tomllib
             with open(artifacts_toml, "rb") as f:
-                reg = _tomllib.load(f)
+                reg = tomllib.load(f)
 
             changed = False
             for sys_entry in reg.get("systems", []):
@@ -773,7 +771,6 @@ def _migrate_kit_sources(config_dir: Path) -> Dict[str, str]:
         return {}
 
     try:
-        import tomllib
         with open(core_toml, "rb") as f:
             data = tomllib.load(f)
     except (OSError, ValueError):

--- a/skills/cypilot/scripts/cypilot/ralphex_export.py
+++ b/skills/cypilot/scripts/cypilot/ralphex_export.py
@@ -18,10 +18,10 @@ import os
 import re
 import subprocess
 import sys
-import tomllib
 from pathlib import Path
 from typing import Optional
 
+from .utils._tomllib_compat import tomllib
 from .utils.files import _read_cypilot_var, core_subpath
 
 logger = logging.getLogger(__name__)

--- a/skills/cypilot/scripts/cypilot/utils/_tomllib_compat.py
+++ b/skills/cypilot/scripts/cypilot/utils/_tomllib_compat.py
@@ -1,0 +1,29 @@
+"""
+Compatibility shim for tomllib (Python 3.11+) / tomli (Python < 3.11).
+
+Import this module instead of importing tomllib directly:
+
+    from cypilot.utils._tomllib_compat import tomllib
+
+@cpt-algo:cpt-cypilot-algo-core-infra-config-management:p1
+"""
+
+import sys
+
+# Python 3.11+ has tomllib in stdlib, earlier versions need tomli
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    try:
+        import tomli as tomllib
+    except ImportError:
+        print(
+            "ERROR: tomllib/tomli not available.\n"
+            "Please either:\n"
+            "  1. Use Python 3.11+ (tomllib is included in stdlib), or\n"
+            "  2. Install tomli: pip install tomli\n",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+__all__ = ["tomllib"]

--- a/skills/cypilot/scripts/cypilot/utils/artifacts_meta.py
+++ b/skills/cypilot/scripts/cypilot/utils/artifacts_meta.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, Dict, Iterator, List, Optional, Set, Tuple
 
+from ._tomllib_compat import tomllib
 from ..constants import ARTIFACTS_REGISTRY_FILENAME
 
 # @cpt-begin:cpt-cypilot-algo-core-infra-registry-parsing:p1:inst-reg-dataclasses
@@ -1053,7 +1054,6 @@ def load_artifacts_meta(adapter_dir: Path) -> Tuple[Optional[ArtifactsMeta], Opt
     # @cpt-begin:cpt-cypilot-algo-core-infra-registry-parsing:p1:inst-reg-parse-merge
     try:
         if path.suffix == ".toml":
-            import tomllib
             with open(path, "rb") as f:
                 data = tomllib.load(f)
         else:
@@ -1067,9 +1067,8 @@ def load_artifacts_meta(adapter_dir: Path) -> Tuple[Optional[ArtifactsMeta], Opt
         if not core_path.is_file():
             core_path = adapter_dir / "core.toml"
         if core_path.is_file():
-            import tomllib as _tl
             with open(core_path, "rb") as f:
-                core = _tl.load(f)
+                core = tomllib.load(f)
             # version and project_root: core.toml is authoritative, artifacts.toml is fallback
             if isinstance(core.get("version"), str) and "version" not in data:
                 data["version"] = core["version"]

--- a/skills/cypilot/scripts/cypilot/utils/layer_discovery.py
+++ b/skills/cypilot/scripts/cypilot/utils/layer_discovery.py
@@ -12,10 +12,10 @@ by walking up the filesystem from the repo root.
 from __future__ import annotations
 
 import logging
-import tomllib
 from pathlib import Path
 from typing import List, Optional
 
+from ._tomllib_compat import tomllib
 from .manifest import ManifestLayer, ManifestLayerState, parse_manifest_v2, _rewrite_component_paths
 # @cpt-end:cpt-cypilot-algo-project-extensibility-walk-up-discovery:p1:inst-imports
 

--- a/skills/cypilot/scripts/cypilot/utils/manifest.py
+++ b/skills/cypilot/scripts/cypilot/utils/manifest.py
@@ -17,11 +17,12 @@ from __future__ import annotations
 
 import re
 import string
-import tomllib
 from dataclasses import dataclass, field, replace
 from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
+
+from ._tomllib_compat import tomllib
 
 
 # ---------------------------------------------------------------------------

--- a/skills/cypilot/scripts/cypilot/utils/toml_utils.py
+++ b/skills/cypilot/scripts/cypilot/utils/toml_utils.py
@@ -10,9 +10,10 @@ TOML utilities for Cypilot config files.
 
 # @cpt-begin:cpt-cypilot-algo-core-infra-toml-utils:p1:inst-toml-datamodel
 import re
-import tomllib
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+from ._tomllib_compat import tomllib
 
 TomlData = Dict[str, Any]
 

--- a/skills/cypilot/scripts/cypilot/utils/whatsnew.py
+++ b/skills/cypilot/scripts/cypilot/utils/whatsnew.py
@@ -11,6 +11,8 @@ import sys
 from pathlib import Path
 from typing import Dict, Tuple
 
+from ._tomllib_compat import tomllib
+
 logger = logging.getLogger(__name__)
 
 # @cpt-begin:cpt-cypilot-algo-kit-whatsnew-display:p1:inst-whatsnew-format
@@ -128,11 +130,6 @@ def read_whatsnew(path: Path) -> Dict[str, Dict[str, str]]:
     Keys may be in format "whatsnew.X.Y.Z" (from TOML section) or just "X.Y.Z".
     """
     if not path.is_file():
-        return {}
-    try:
-        import tomllib
-    except ModuleNotFoundError as e:
-        logger.debug("Failed to parse %s: %s", path, e)
         return {}
     try:
         with open(path, "rb") as f:

--- a/tests/test_tomllib_compat.py
+++ b/tests/test_tomllib_compat.py
@@ -1,0 +1,73 @@
+import importlib
+import sys
+import types
+
+import pytest
+
+
+MODULE_PATH = "cypilot.utils._tomllib_compat"
+
+
+def _reload_module():
+    # Ensure fresh import
+    sys.modules.pop(MODULE_PATH, None)
+    return importlib.import_module(MODULE_PATH)
+
+
+def test_stdlib_tomllib(monkeypatch):
+    dummy = types.ModuleType("tomllib")
+    dummy.DUMMY_FLAG = "stdlib"
+
+    # Simulate Python >= 3.11 and a stdlib tomllib present
+    monkeypatch.setitem(sys.modules, "tomllib", dummy)
+    monkeypatch.setattr(sys, "version_info", (3, 11))
+
+    mod = _reload_module()
+    assert hasattr(mod, "tomllib")
+    assert mod.tomllib is dummy
+    assert mod.__all__ == ["tomllib"]
+
+
+def test_tomli_fallback(monkeypatch):
+    dummy = types.ModuleType("tomli")
+    dummy.DUMMY_FLAG = "tomli"
+
+    # Simulate Python < 3.11 and tomli installed
+    monkeypatch.setattr(sys, "version_info", (3, 10))
+    monkeypatch.setitem(sys.modules, "tomli", dummy)
+
+    mod = _reload_module()
+    assert hasattr(mod, "tomllib")
+    # When tomli is used, the compat module aliases it as tomllib
+    assert mod.tomllib is dummy
+    assert mod.__all__ == ["tomllib"]
+
+
+def test_no_tomli_exits_with_error(monkeypatch, capsys):
+    # Simulate Python < 3.11 and tomli NOT installed
+    monkeypatch.setattr(sys, "version_info", (3, 10))
+    # Ensure tomli and tomllib are not present
+    monkeypatch.delitem(sys.modules, "tomli", raising=False)
+    monkeypatch.delitem(sys.modules, "tomllib", raising=False)
+    # Also ensure our target module is not cached
+    sys.modules.pop(MODULE_PATH, None)
+    # Force ImportError for tomli/tomllib even if installed in this environment
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name in ("tomli", "tomllib"):
+            raise ImportError
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+
+    with pytest.raises(SystemExit) as ei:
+        importlib.import_module(MODULE_PATH)
+
+    # The compat module calls sys.exit(1) on missing dependency
+    assert ei.value.code == 1
+    captured = capsys.readouterr()
+    assert "ERROR: tomllib/tomli not available" in captured.err
+


### PR DESCRIPTION
Add backward compatibility for Python versions < 3.11 by creating a centralized tomllib compatibility shim that falls back to the *tomli* backport package when the stdlib tomllib is not available.

Changes:
- Created _tomllib_compat.py module that checks Python version and imports tomllib (3.11+) or tomli (<3.11) with helpful error message
- Replaced all direct tomllib imports across 13 files with imports from the compatibility module
- Removed inline try/except tomllib import blocks in favor of centralized compatibility handling

Affected modules:
- utils: toml_utils, artifacts_meta, layer_discovery, manifest, whatsnew
- commands: agents, init, kit, update, adapter_info, resolve_vars, _core_config
- ralphex_export

The compatibility module provides clear guidance when neither tomllib nor tomli are available, instructing users to either upgrade to Python 3.11+ or install the tomli backport package.

Fixes ModuleNotFoundError: No module named 'tomllib' on Python < 3.11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized and unified TOML parsing to improve cross‑Python version compatibility and reduce duplication.
* **Tests**
  * Added tests covering TOML parser selection and failure scenarios to ensure consistent behavior across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->